### PR TITLE
fix: export some internal types for go doc generation

### DIFF
--- a/hotp/hotp.go
+++ b/hotp/hotp.go
@@ -10,15 +10,15 @@ import (
 	"math"
 )
 
-type hotp struct {
+type HOTP struct {
 	hash   func() hash.Hash
 	digits int
 }
 
 // New initialises a new HOTP generator using the supplied hashing
 // function and number of digits.
-func New(hash func() hash.Hash, digits int) *hotp {
-	return &hotp{
+func New(hash func() hash.Hash, digits int) *HOTP {
+	return &HOTP{
 		hash:   hash,
 		digits: digits,
 	}
@@ -26,7 +26,7 @@ func New(hash func() hash.Hash, digits int) *hotp {
 
 // Generate generates a HOTP (HMAC-based One-Time Password) code given
 // the shared secret and count.
-func (o *hotp) Generate(secret []byte, count int64) string {
+func (o *HOTP) Generate(secret []byte, count int64) string {
 	countBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(countBytes, uint64(count))
 

--- a/options.go
+++ b/options.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 )
 
-type option func(*otp) error
+type option func(*OTP) error
 
-func (o *otp) applyOpts(opts ...option) error {
+func (o *OTP) applyOpts(opts ...option) error {
 	for _, opt := range opts {
 		if err := opt(o); err != nil {
 			return err
@@ -21,28 +21,28 @@ func (o *otp) applyOpts(opts ...option) error {
 }
 
 func WithIssuer(issuer string) option {
-	return func(o *otp) error {
+	return func(o *OTP) error {
 		o.issuer = issuer
 		return nil
 	}
 }
 
 func WithCount(count int64) option {
-	return func(o *otp) error {
+	return func(o *OTP) error {
 		o.count = count
 		return nil
 	}
 }
 
 func WithSecret(secret []byte) option {
-	return func(o *otp) error {
+	return func(o *OTP) error {
 		o.secret = secret
 		return nil
 	}
 }
 
 func WithBase32Secret(s string) option {
-	return func(o *otp) error {
+	return func(o *OTP) error {
 		secret, err := Base32Decode(s)
 		if err != nil {
 			return fmt.Errorf("failed to decode base32 secret: %w", err)
@@ -53,14 +53,14 @@ func WithBase32Secret(s string) option {
 }
 
 func WithHOTP() option {
-	return func(o *otp) error {
+	return func(o *OTP) error {
 		o.algorithm = HOTP
 		return nil
 	}
 }
 
-func WithHashingAlgorithm(ha hashingAlgorithm) option {
-	return func(o *otp) error {
+func WithHashingAlgorithm(ha HashingAlgorithm) option {
+	return func(o *OTP) error {
 		switch ha {
 		case SHA1:
 			o.hashingAlgorithm = sha1.New
@@ -77,7 +77,7 @@ func WithHashingAlgorithm(ha hashingAlgorithm) option {
 }
 
 func WithPeriod(period int) option {
-	return func(o *otp) error {
+	return func(o *OTP) error {
 		if period <= 0 {
 			return errors.New("period must be greater than 0")
 		}
@@ -88,7 +88,7 @@ func WithPeriod(period int) option {
 }
 
 func WithDigits(digits int) option {
-	return func(o *otp) error {
+	return func(o *OTP) error {
 		if digits <= 0 {
 			return errors.New("digits must be greater than 0")
 		}

--- a/otp.go
+++ b/otp.go
@@ -9,16 +9,16 @@ import (
 	"github.com/Jaytpa01/gotp/totp"
 )
 
-type algorithm int
-type hashingAlgorithm int
+type Algorithm int
+type HashingAlgorithm int
 
 const (
-	TOTP algorithm = iota
+	TOTP Algorithm = iota
 	HOTP
 )
 
 const (
-	SHA1 hashingAlgorithm = iota
+	SHA1 HashingAlgorithm = iota
 	SHA256
 	SHA512
 )
@@ -31,8 +31,8 @@ const (
 
 var DefaultHashingAlgorithm = sha1.New
 
-type otp struct {
-	algorithm        algorithm
+type OTP struct {
+	algorithm        Algorithm
 	hashingAlgorithm func() hash.Hash
 	secret           []byte
 	digits           int
@@ -50,13 +50,13 @@ type otp struct {
 	issuer      string
 }
 
-func New(accountName string, options ...option) (*otp, error) {
+func New(accountName string, options ...option) (*OTP, error) {
 	s, err := RandomSecret(20)
 	if err != nil {
 		return nil, err
 	}
 
-	otp := &otp{
+	otp := &OTP{
 		accountName:      accountName,
 		algorithm:        TOTP,
 		hashingAlgorithm: DefaultHashingAlgorithm,
@@ -73,7 +73,7 @@ func New(accountName string, options ...option) (*otp, error) {
 	return otp, nil
 }
 
-func (o *otp) Generate() (string, error) {
+func (o *OTP) Generate() (string, error) {
 	switch o.algorithm {
 	case TOTP:
 		return o.generateTOTP()
@@ -87,21 +87,21 @@ func (o *otp) Generate() (string, error) {
 
 }
 
-func (o *otp) Secret() []byte {
+func (o *OTP) Secret() []byte {
 	return o.secret
 }
 
-func (o *otp) Base32Secret() string {
+func (o *OTP) Base32Secret() string {
 	return Base32Encode(o.secret)
 }
 
-func (o *otp) At(time time.Time) *otp {
+func (o *OTP) At(time time.Time) *OTP {
 	o.when = time
 	return o
 }
 
-func (o *otp) generateTOTP() (string, error) {
-	// use the current timestamp for otp generation unless explicitly set otherwise
+func (o *OTP) generateTOTP() (string, error) {
+	// use the current timestamp for OTP generation unless explicitly set otherwise
 	when := time.Now()
 	if !o.when.IsZero() {
 		when = o.when
@@ -110,6 +110,6 @@ func (o *otp) generateTOTP() (string, error) {
 	return totp.New(o.hashingAlgorithm, o.digits, o.period).Generate(o.secret, when)
 }
 
-func (o *otp) generateHOTP() (string, error) {
+func (o *OTP) generateHOTP() (string, error) {
 	return hotp.New(o.hashingAlgorithm, o.digits).Generate(o.secret, o.count), nil
 }

--- a/otp_test.go
+++ b/otp_test.go
@@ -27,7 +27,7 @@ func TestDefaultOTP(t *testing.T) {
 	tests := []struct {
 		epoch            int64
 		expectedTOTP     string
-		hashingAlgorithm hashingAlgorithm
+		hashingAlgorithm HashingAlgorithm
 		secret           []byte
 	}{
 		{59, "94287082", SHA1, sha1Secret},

--- a/totp/totp.go
+++ b/totp/totp.go
@@ -10,7 +10,7 @@ import (
 	"github.com/Jaytpa01/gotp/hotp"
 )
 
-type totp struct {
+type TOTP struct {
 	hash   func() hash.Hash
 	digits int
 	period int
@@ -18,8 +18,8 @@ type totp struct {
 
 // New initialises a new HOTP generator using the supplied hashing
 // function, number of digits, and time period.
-func New(hash func() hash.Hash, digits int, period int) *totp {
-	return &totp{
+func New(hash func() hash.Hash, digits int, period int) *TOTP {
+	return &TOTP{
 		hash:   hash,
 		digits: digits,
 		period: period,
@@ -28,7 +28,7 @@ func New(hash func() hash.Hash, digits int, period int) *totp {
 
 // Generate generates a TOTP (Time-based One-Time Password) code given
 // the shared secret and a time.
-func (o *totp) Generate(secret []byte, when time.Time) (string, error) {
+func (o *TOTP) Generate(secret []byte, when time.Time) (string, error) {
 	err := o.validate()
 	if err != nil {
 		return "", err
@@ -64,7 +64,7 @@ func padSecret(secret []byte, minLength int) []byte {
 	return paddedSecret
 }
 
-func (o *totp) validate() error {
+func (o *TOTP) validate() error {
 	if o.period <= 0 {
 		return errors.New("period must be greater than 0")
 	}


### PR DESCRIPTION
Go docs weren't generating any docs for the previously unexported types.